### PR TITLE
fix 找不到chrome 启动chrome失败的问题

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,11 +1,24 @@
 import { app, BrowserWindow, ipcMain, shell, dialog, Menu } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import { ChromeManager } from './chrome-manager';
 import { ApiService } from './api-service';
 import { ConfigManager } from './config-manager';
 import { TokenService } from './token-service';
 import { TokenStorage } from './token-storage';
+
+// 设置Windows控制台编码为UTF-8，解决中文乱码问题
+if (os.platform() === 'win32') {
+  process.env['PYTHONIOENCODING'] = 'utf-8';
+  // 尝试设置控制台代码页为UTF-8
+  try {
+    const { execSync } = require('child_process');
+    execSync('chcp 65001', { stdio: 'ignore' });
+  } catch (e) {
+    // 忽略错误
+  }
+}
 
 let mainWindow: BrowserWindow | null = null;
 const chromeManager = new ChromeManager();


### PR DESCRIPTION
主要修改 启动chrome方式 中文输出日志和chrome多个位置
  private getChromePath(): string {
    const platform = process.platform;
    
    if (platform === 'win32') {
      // 尝试多个可能的Chrome安装位置
      const possiblePaths = [
        'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
        'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
        'C:\\Users\\' + process.env.USERNAME + '\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe'
      ];
      
      // 检查文件是否存在
      for (const chromePath of possiblePaths) {
        if (fs.existsSync(chromePath)) {
          return chromePath;
        }
      }
      
      // 如果都不存在，返回最常见的位置
      console.warn('⚠️ [ChromeManager] 未找到Chrome，使用默认路径');
      return possiblePaths[0];
    } else if (platform === 'darwin') {
      return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
    } else {
      return '/usr/bin/google-chrome';
    }
  }
}